### PR TITLE
Add basic save system and game manager

### DIFF
--- a/aitrygame/Assets/Scripts.meta
+++ b/aitrygame/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 33949d17a370426dac7d49c0a9a5ed97
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/aitrygame/Assets/Scripts/GameManager.cs
+++ b/aitrygame/Assets/Scripts/GameManager.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+public class GameManager : MonoBehaviour
+{
+    public SaveData saveData;
+
+    private void Awake()
+    {
+        saveData = SaveSystem.Load();
+    }
+
+    public void AddResource(string resource, int amount)
+    {
+        if (saveData.resources.ContainsKey(resource))
+            saveData.resources[resource] += amount;
+        else
+            saveData.resources[resource] = amount;
+    }
+
+    public int GetResource(string resource)
+    {
+        return saveData.resources.TryGetValue(resource, out var value) ? value : 0;
+    }
+
+    public void AddBuilding(string buildingId)
+    {
+        saveData.buildings.Add(buildingId);
+    }
+
+    public void SaveGame()
+    {
+        SaveSystem.Save(saveData);
+    }
+
+    private void OnApplicationQuit()
+    {
+        SaveGame();
+    }
+}
+

--- a/aitrygame/Assets/Scripts/GameManager.cs.meta
+++ b/aitrygame/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94fde3f895624715aedd1b097411db4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/aitrygame/Assets/Scripts/SaveSystem.cs
+++ b/aitrygame/Assets/Scripts/SaveSystem.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+
+[Serializable]
+public class SaveData
+{
+    public Dictionary<string, int> resources = new Dictionary<string, int>();
+    public List<string> buildings = new List<string>();
+}
+
+public static class SaveSystem
+{
+    private static string SavePath => Path.Combine(Application.persistentDataPath, "save.json");
+
+    public static void Save(SaveData data)
+    {
+        try
+        {
+            var json = JsonUtility.ToJson(data);
+            File.WriteAllText(SavePath, json);
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Failed to save game: {e}");
+        }
+    }
+
+    public static SaveData Load()
+    {
+        try
+        {
+            if (File.Exists(SavePath))
+            {
+                var json = File.ReadAllText(SavePath);
+                return JsonUtility.FromJson<SaveData>(json);
+            }
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Failed to load game: {e}");
+        }
+        return new SaveData();
+    }
+}
+

--- a/aitrygame/Assets/Scripts/SaveSystem.cs.meta
+++ b/aitrygame/Assets/Scripts/SaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be809248482147a2942e8b094bdf8695
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- implement `SaveSystem` for JSON-based persistence
- add `GameManager` to load and save resource/building data

## Testing
- `dotnet build` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_689c43235d8883268f8a861b2283f70e